### PR TITLE
Restrict Google Java Format to versions below 1.29.0

### DIFF
--- a/default.json
+++ b/default.json
@@ -12,6 +12,10 @@
       "packagePatterns": [
         "^org.komapper:"
       ]
+    },
+    {
+      "matchPackageNames": ["com.google.googlejavaformat"],
+      "allowedVersions": "<1.29.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Added version restriction for `com.google.googlejavaformat` to versions below 1.29.0

## Test plan
- Verify Renovate configuration is valid
- Confirm version restrictions work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)