### PR TITLE
Fix package name for google-java-format

### DIFF
--- a/default.json
+++ b/default.json
@@ -14,7 +14,7 @@
       ]
     },
     {
-      "matchPackageNames": ["com.google.googlejavaformat"],
+      "matchPackageNames": ["com.google.googlejavaformat:google-java-format"],
       "allowedVersions": "<1.29.0"
     }
   ]


### PR DESCRIPTION
## Summary
- Update `matchPackageNames` to use the full Maven coordinates `com.google.googlejavaformat:google-java-format` instead of just the group ID `com.google.googlejavaformat`

## Rationale
The current configuration using only the group ID may not properly match the package. Using the full Maven coordinates ensures Renovate correctly identifies and applies the version restriction for google-java-format.

## Test plan
- [ ] Verify that Renovate correctly applies the `allowedVersions: "<1.29.0"` constraint to google-java-format updates
- [ ] Confirm that the package matching works as expected in the Renovate configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)